### PR TITLE
Prevent "A function declaration without a prototype is deprecated in all versions of C and is not supported in C2X" warning

### DIFF
--- a/unit_tests/testers/test_linked_list.c
+++ b/unit_tests/testers/test_linked_list.c
@@ -6,7 +6,7 @@
 /*   By: vscabell <vscabell@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/20 02:48:54 by vscabell          #+#    #+#             */
-/*   Updated: 2020/09/24 02:43:34 by vscabell         ###   ########.fr       */
+/*   Updated: 2024/06/19 18:03:43 by cassepipe        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ void	list_push_front(t_list **begin_list, void *data)
 	}
 }
 
-void	initialize_list(t_list **list, int index, void (*ft)())
+void	initialize_list(t_list **list, int index, void (*ft)(t_list**, const char*))
 {
 	if (index == 0)
 		*list = NULL;

--- a/unit_tests/testers/test_read.c
+++ b/unit_tests/testers/test_read.c
@@ -6,13 +6,13 @@
 /*   By: vscabell <vscabell@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/20 20:20:50 by vscabell          #+#    #+#             */
-/*   Updated: 2021/04/09 13:33:43 by abrabant         ###   ########.fr       */
+/*   Updated: 2024/06/19 18:00:54 by cassepipe        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "header_test.h"
 
-void	result(ssize_t (*ft)(), int fd)
+void	result(ssize_t (*ft)(int, void *, size_t), int fd)
 {
 	ssize_t	ret;
 	char	buffer[101] = {0};

--- a/unit_tests/testers/test_strcmp.c
+++ b/unit_tests/testers/test_strcmp.c
@@ -6,13 +6,13 @@
 /*   By: vscabell <vscabell@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/20 19:49:31 by vscabell          #+#    #+#             */
-/*   Updated: 2020/09/26 19:18:04 by vscabell         ###   ########.fr       */
+/*   Updated: 2024/06/19 18:01:27 by cassepipe        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "header_test.h"
 
-static void	result(int (*ft)(), char *s1, char *s2)
+static void	result(int (*ft)(const char *, const char *), char *s1, char *s2)
 {
 	printf("s1 = \"%s\" | ", s1);
 	printf("s2 = \"%s\"\n", s2);

--- a/unit_tests/testers/test_strcpy.c
+++ b/unit_tests/testers/test_strcpy.c
@@ -6,13 +6,13 @@
 /*   By: vscabell <vscabell@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/20 19:49:31 by vscabell          #+#    #+#             */
-/*   Updated: 2020/09/26 19:17:57 by vscabell         ###   ########.fr       */
+/*   Updated: 2024/06/19 17:57:50 by cassepipe        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "header_test.h"
 
-static void	result(char *(*ft)(), char *src)
+static void	result(char *(*ft)(char*, const char*), char *src)
 {
 	char	dst[100];
 

--- a/unit_tests/testers/test_strdup.c
+++ b/unit_tests/testers/test_strdup.c
@@ -6,13 +6,13 @@
 /*   By: vscabell <vscabell@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/20 19:49:31 by vscabell          #+#    #+#             */
-/*   Updated: 2020/09/26 19:17:26 by vscabell         ###   ########.fr       */
+/*   Updated: 2024/06/19 17:56:35 by cassepipe        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "header_test.h"
 
-static void	result(char *(*ft)(), char *src)
+static void	result(char *(*ft)(const char*), char *src)
 {
 	char *dst;
 

--- a/unit_tests/testers/test_strlen.c
+++ b/unit_tests/testers/test_strlen.c
@@ -6,13 +6,13 @@
 /*   By: vscabell <vscabell@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/20 19:49:31 by vscabell          #+#    #+#             */
-/*   Updated: 2020/09/26 19:12:40 by vscabell         ###   ########.fr       */
+/*   Updated: 2024/06/19 17:56:17 by cassepipe        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "header_test.h"
 
-static void	result(size_t (*ft)(), char *str)
+static void	result(size_t (*ft)(const char*), char *str)
 {
 	printf("string = %s\n", str);
 	printf("return = %lu\n", ft(str));

--- a/unit_tests/testers/test_write.c
+++ b/unit_tests/testers/test_write.c
@@ -6,13 +6,13 @@
 /*   By: vscabell <vscabell@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/20 20:20:50 by vscabell          #+#    #+#             */
-/*   Updated: 2020/09/26 19:21:49 by vscabell         ###   ########.fr       */
+/*   Updated: 2024/06/19 17:55:32 by cassepipe        ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "header_test.h"
 
-static void	result(ssize_t (*ft)(), int fd, char *str)
+static void	result(ssize_t (*ft)(int, const void*, size_t), int fd, char *str)
 {
 	ssize_t	ret;
 


### PR DESCRIPTION
With `clang version 17.0.6` I get the following warning when compiling the tests: 
```
error: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
```

Fixed by annotating function pointer parameters with their respective types